### PR TITLE
Declare helo variable, fix wrong comment

### DIFF
--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -58,9 +58,13 @@ our $smtp_server = 'localhost';
 # port to connect to; defaults to 25 for non-SSL, 465 for 'ssl', 587 for 'starttls'
 our $smtp_server_port = 25;
 
-# this is the helo we [the vacation script] use on connection; you may need to change this to your hostname or something,
-# depending upon what smtp helo restrictions you have in place within Postfix. 
-our $smtp_client = 'localhost';
+# this is the local address [the vacation script] uses on outgoing connection; you may need to change this to your outgoing ip address
+# or leave it blank for default address
+our $smtp_client = '127.0.0.1';
+
+# this is the helo name [the vacation script] uses on outgoing connection; you may need to change this to your hostname 
+# or leave it blank for default
+our $smtp_helo = '';
 
 # send mail encrypted or plaintext
 # if 'starttls', use STARTTLS; if 'ssl' (or 1), connect securely; otherwise, no security
@@ -464,6 +468,7 @@ sub send_vacation_email {
             ssl  => $smtp_ssl,
             timeout => $smtp_timeout,
             localaddr => $smtp_client,
+            helo => $smtp_helo,
             debug => 0,
         };
 


### PR DESCRIPTION
$smtp_client sets  the local client address and is not the outgoing helo name.